### PR TITLE
Add Rasgos JSON field and migration

### DIFF
--- a/heroesAPI/Data/AppDbContext.cs
+++ b/heroesAPI/Data/AppDbContext.cs
@@ -17,12 +17,12 @@ public class AppDbContext : DbContext
         base.OnModelCreating(modelBuilder);
         modelBuilder.HasDefaultSchema("heroescodefirst");
 
-        // Aquí configuraremos el JSON más adelante cuando descomentes la propiedad en el modelo
-        /*
+        // Aquí configuraremos el JSON 
+        
         modelBuilder.Entity<Personaje>()
             .Property(p => p.Rasgos)
             .HasColumnType("jsonb");
-        */
+        
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/heroesAPI/Migrations/20260206193431_addJSON.Designer.cs
+++ b/heroesAPI/Migrations/20260206193431_addJSON.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using heroesAPI.Data;
@@ -11,9 +12,11 @@ using heroesAPI.Data;
 namespace heroesAPI.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260206193431_addJSON")]
+    partial class addJSON
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/heroesAPI/Migrations/20260206193431_addJSON.cs
+++ b/heroesAPI/Migrations/20260206193431_addJSON.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace heroesAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class addJSON : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Rasgos",
+                schema: "heroescodefirst",
+                table: "Personajes",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Rasgos",
+                schema: "heroescodefirst",
+                table: "Personajes");
+        }
+    }
+}

--- a/heroesAPI/Models/Personaje.cs
+++ b/heroesAPI/Models/Personaje.cs
@@ -16,7 +16,10 @@ public abstract class Personaje
     public DateTime FechaCreacion { get; set; } = DateTime.UtcNow;
     public string? Gremio { get; set; }
 
-    // El campo JSON lo añadiremos posteriormente
+    // El campo JSON que contiene los rasgos del personaje
+    [Required]
+    public string Rasgos { get; set; } = string.Empty;
+
 }
 
 [Table("Guerreros")]


### PR DESCRIPTION
Introduce a required Rasgos property on Personaje (string) to hold character traits as JSON, configure EF Core to map it to Postgres jsonb in AppDbContext, and add a migration  that adds a non-null jsonb Rasgos column to the heroescodefirst. Personajes table with a default empty string. Also update the model snapshot and include the auto-generated migration designer.