### PR TITLE
Configure Npgsql via DI and appsettings

### DIFF
--- a/heroesAPI/Data/AppDbContext.cs
+++ b/heroesAPI/Data/AppDbContext.cs
@@ -25,12 +25,6 @@ public class AppDbContext : DbContext
         
     }
 
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        base.OnConfiguring(optionsBuilder);
-        optionsBuilder.UseNpgsql("Host=localhost;Port=5441;Database=heroesapi;SearchPath=heroescodefirst;Username=heroesuser;Password=Abcd1234");
-    }
-
     public DbSet<Personaje> Personajes { get; set; }
 
     public DbSet<Guerrero> Guerreros { get; set; }

--- a/heroesAPI/Program.cs
+++ b/heroesAPI/Program.cs
@@ -1,8 +1,15 @@
+using heroesAPI.Data;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseNpgsql(connectionString));
 
 var app = builder.Build();
 

--- a/heroesAPI/appsettings.json
+++ b/heroesAPI/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5441;Database=heroesapi;SearchPath=heroescodefirst;Username=heroesuser;Password=Abcd1234"
+  }
 }


### PR DESCRIPTION
Remove hardcoded Npgsql configuration from AppDbContext.OnConfiguring and register AppDbContext in Program.cs using AddDbContext with UseNpgsql. Add DefaultConnection to appsettings.json so the connection string is sourced from configuration. This moves DB configuration into DI/configuration, avoids a hardcoded connection in the DbContext class, and enables easier environment-specific overrides.