### PR TITLE
Add complex query endpoints and Swagger

### DIFF
--- a/heroesAPI/heroesAPI.csproj
+++ b/heroesAPI/heroesAPI.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Introduce two advanced query endpoints and enable Swagger tooling:

- Add /api/consultas/buscar-miedo which queries the Postgres JSONB "Rasgos" field via FromSqlRaw to find characters with a specific fear.
- Add /api/consultas/magos-clerigos-top which unions Magos and Clérigos with Nivel > 50 and returns them ordered by level.
- Add Swashbuckle.AspNetCore package to the project file to provide Swagger UI; keep UseSwaggerUI() with a comment about the required namespace.
- Minor change: AddSwaggerGen() call is assigned to a local variable (no functional change).

These changes add inspectable API docs and sample complex queries for JSONB and multi-table unions.